### PR TITLE
- Billing: subscriptions, invoices, invoice_lines, payments

### DIFF
--- a/models/staging/billing/schema.yml
+++ b/models/staging/billing/schema.yml
@@ -1,0 +1,67 @@
+version: 2
+models:
+  - name: stg_billing_subscriptions
+    columns:
+      - name: subscription_id
+        tests: [not_null, unique]
+      - name: prod_account_id
+        tests:
+          - relationships:
+              to: source('axiomly_raw','product_accounts')
+              field: pk_prod_account_id
+      - name: product_sku
+        tests:
+          - relationships:
+              to: source('axiomly_raw','admin_plan_catalog')
+              field: product_sku
+      - name: status
+        tests:
+          - accepted_values:
+              values: ["active","trial","cancelled","past_due"]
+
+  - name: stg_billing_invoices
+    columns:
+      - name: invoice_id
+        tests: [not_null, unique]
+      - name: subscription_id
+        tests:
+          - relationships:
+              to: ref('stg_billing_subscriptions')
+              field: subscription_id
+      - name: prod_account_id
+        tests:
+          - relationships:
+              to: source('axiomly_raw','product_accounts')
+              field: pk_prod_account_id
+      - name: invoice_status
+        tests:
+          - accepted_values:
+              values: ["draft","open","finalized","paid","uncollectible","void"]
+
+  - name: stg_billing_invoice_lines
+    columns:
+      - name: invoice_line_id
+        tests: [not_null, unique]
+      - name: invoice_id
+        tests:
+          - relationships:
+              to: ref('stg_billing_invoices')
+              field: invoice_id
+      - name: line_type
+        tests:
+          - accepted_values:
+              values: ["subscription","usage","discount","tax"]
+
+  - name: stg_billing_payments
+    columns:
+      - name: payment_id
+        tests: [not_null, unique]
+      - name: invoice_id
+        tests:
+          - relationships:
+              to: ref('stg_billing_invoices')
+              field: invoice_id
+      - name: status
+        tests:
+          - accepted_values:
+              values: ["succeeded","failed","refunded"]

--- a/models/staging/billing/stg_billing_invoice_lines.sql
+++ b/models/staging/billing/stg_billing_invoice_lines.sql
@@ -1,0 +1,12 @@
+{{ config(materialized="view") }}
+
+select
+  pk_invoice_line_id as invoice_line_id,
+  fk_invoice_id      as invoice_id,
+  lower(line_type)   as line_type,
+  product_sku,
+  quantity,
+  unit_amount,
+  amount,
+  description
+from {{ source('axiomly_raw','billing_invoice_lines') }}

--- a/models/staging/billing/stg_billing_invoices.sql
+++ b/models/staging/billing/stg_billing_invoices.sql
@@ -1,0 +1,20 @@
+{{ config(materialized="view") }}
+
+select
+  pk_invoice_id      as invoice_id,
+  fk_subscription_id as subscription_id,
+  fk_prod_account_id as prod_account_id,
+  invoice_number,
+  upper(currency)    as currency,
+  subtotal,
+  tax,
+  total,
+  amount_due,
+  amount_paid,
+  lower(invoice_status) as invoice_status,
+  invoice_date,
+  due_date,
+  finalized_at,
+  paid_at,
+  voided_at
+from {{ source('axiomly_raw','billing_invoices') }}

--- a/models/staging/billing/stg_billing_payments.sql
+++ b/models/staging/billing/stg_billing_payments.sql
@@ -1,0 +1,12 @@
+{{ config(materialized="view") }}
+
+select
+  pk_payment_id as payment_id,
+  fk_invoice_id as invoice_id,
+  fk_prod_account_id as prod_account_id,
+  upper(currency) as currency,
+  amount,
+  lower(status) as status,
+  lower(payment_method) as payment_method,
+  created_at
+from {{ source('axiomly_raw','billing_payments') }}

--- a/models/staging/billing/stg_billing_subscriptions.sql
+++ b/models/staging/billing/stg_billing_subscriptions.sql
@@ -1,0 +1,16 @@
+{{ config(materialized="view") }}
+
+select
+  pk_subscription_id as subscription_id,
+  fk_prod_account_id as prod_account_id,
+  product_sku,
+  plan_tier,
+  billing_interval,
+  current_period_start,
+  current_period_end,
+  lower(status) as status,
+  cancel_at,
+  canceled_at,
+  created_at,
+  updated_at
+from {{ source('axiomly_raw','billing_subscriptions') }}


### PR DESCRIPTION
This PR introduces the billing staging layer for subscription and invoice data.

**Changes**
- stg_billing_subscriptions: account + plan catalog links, status normalization
- stg_billing_invoices: invoice headers, status/currency normalization
- stg_billing_invoice_lines: detailed line items (subscription, usage, tax, discount)
- stg_billing_payments: normalized status + payment methods
- schema.yml: added PK/FK integrity checks and accepted_values tests

**Why**
Provides a clean billing foundation for downstream revenue metrics (MRR, ARR, NRR), cohort retention, and cash flow analysis. Ensures strong referential integrity between subscriptions, invoices, invoice lines, and payments.