### PR TITLE
Staging: Support and Marketing models

### DIFF
--- a/models/marketing/schema.yml
+++ b/models/marketing/schema.yml
@@ -1,0 +1,15 @@
+version: 2
+models:
+  - name: stg_marketing_email_events
+    columns:
+      - name: email_event_id
+        tests: [not_null, unique]
+      - name: crm_contact_id
+        tests:
+          - relationships:
+              to: source('axiomly_raw','crm_contacts')
+              field: pk_contact_id
+      - name: event_type
+        tests:
+          - accepted_values:
+              values: ["sent","open","click","bounce","unsubscribe"]

--- a/models/marketing/stg_marketing_email_events.sql
+++ b/models/marketing/stg_marketing_email_events.sql
@@ -1,0 +1,9 @@
+{{ config(materialized="view") }}
+
+select
+  pk_email_event_id as email_event_id,
+  fk_contact_id as crm_contact_id,
+  campaign_id,
+  lower(event_type) as event_type,
+  event_ts
+from {{ source('axiomly_raw','marketing_email_events') }}

--- a/models/staging/support/schema.yml
+++ b/models/staging/support/schema.yml
@@ -1,0 +1,25 @@
+version: 2
+models:
+  - name: stg_support_tickets
+    columns:
+      - name: ticket_id
+        tests: [not_null, unique]
+      - name: prod_account_id
+        tests:
+          - relationships:
+              to: source('axiomly_raw','product_accounts')
+              field: pk_prod_account_id
+      - name: prod_user_id
+        tests:
+          - relationships:
+              to: source('axiomly_raw','product_users')
+              field: pk_prod_user_id
+              where: "prod_user_id is not null"
+      - name: priority
+        tests:
+          - accepted_values:
+              values: ["low","normal","high","urgent"]
+      - name: status
+        tests:
+          - accepted_values:
+              values: ["open","pending","solved","closed"]

--- a/models/staging/support/stg_support_tickets.sql
+++ b/models/staging/support/stg_support_tickets.sql
@@ -1,0 +1,15 @@
+{{ config(materialized="view") }}
+
+select
+  pk_ticket_id as ticket_id,
+  fk_prod_account_id as prod_account_id,
+  fk_prod_user_id as prod_user_id,
+  lower(priority) as priority,
+  lower(status) as status,
+  subject,
+  lower(channel) as channel,
+  created_at,
+  first_response_at,
+  resolved_at,
+  closed_at
+from {{ source('axiomly_raw','support_tickets') }}


### PR DESCRIPTION
This PR introduces staging models for support tickets and marketing email events.

**Changes**
- stg_support_tickets: normalized priority/status/channel, PK/FK tests
- stg_marketing_email_events: normalized event_type, FK to CRM contacts
- schema.yml: added integrity + accepted_values tests

**Why**
These staging models prepare support and marketing data for downstream analytics:
- Support → SLA metrics (first response, resolution time, backlog) by account
- Marketing → campaign performance and funnel attribution
Together they complete the non-financial customer-facing domains of the staging layer.
